### PR TITLE
Add aurora-mysql and aurora-postgresql engine options

### DIFF
--- a/library/rds_cluster.py
+++ b/library/rds_cluster.py
@@ -28,6 +28,8 @@ options:
       - Used when creating a new cluster or restoring from snapshot.
     choices:
       - aurora
+      - aurora-mysql
+      - aurora-postgresql
     default: aurora
   engine_version:
     description:
@@ -240,7 +242,7 @@ def main():
         availability_zones=dict(type='list', required=False),
         cluster_id=dict(required=True),
         database_name=dict(required=False),
-        engine=dict(required=False, choices=['aurora'], default='aurora'),
+        engine=dict(required=False, choices=['aurora', 'aurora-mysql', 'aurora-postgresql'], default='aurora'),
         engine_version=dict(required=False),
         master_username=dict(required=False),
         master_password=dict(required=False, no_log=True),

--- a/library/rds_cluster_instance.py
+++ b/library/rds_cluster_instance.py
@@ -69,6 +69,8 @@ options:
       - Used when state=present and instance does not exist.
     choices:
         - aurora
+        - aurora-mysql
+        - aurora-postgresql
     required: false
     default: aurora
   instance_id:
@@ -341,7 +343,7 @@ def main():
         cloudwatch_logs_exports = dict(required=False, default=None),
         cluster_id = dict(required=False),
         copy_tags_to_snapshot = dict(required=False, type='bool', default=True),
-        engine = dict(required=False, choices=['aurora'], default='aurora'),
+        engine = dict(required=False, choices=['aurora', 'aurora-mysql', 'aurora-postgresql'], default='aurora'),
         instance_id = dict(required=True),
         instance_type = dict(required=False),
         monitoring_interval = dict(required=False, type='int', default=0, choices=[0, 1, 5, 10, 15, 30, 60]),


### PR DESCRIPTION
In going about trying to write a playbook to create a Postgres-compatible RDS cluster, I found that the ability to do this doesn't exist in the latest version of Ansible (2.7.8). Upon searching, I found your drop in module which got me most of the way there. However, it doesn't allow for specifying some of the newer valid options. 

This PR adds aurora-mysql and aurora-postgresql as options for the engine parameter.